### PR TITLE
Block autoplay in general because it's almost always ads

### DIFF
--- a/background.js
+++ b/background.js
@@ -86,6 +86,12 @@ const player_hook = (details) => {
   const context = request["playbackContext"]["contentPlaybackContext"];
   const video_id = request["videoId"];
 
+  // Autoplay is probably always bad
+  if (context["autoplay"]) {
+    do_log("Detected autoplay, skipping");
+    return;
+  }
+
   // Don't redirect on hover preview
   if (context["autonav"]) {
     do_log("Detected hover preview, skipping");


### PR DESCRIPTION
Recently Youtube has started loading ad videos in the background which the addon confuses with legitimate user requests. This change summarily blocks all requests for videos with the autoplay tag set.